### PR TITLE
Specify if extra fields are expected when creating an object parser

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # Revision history for yaml-combinators
 
+## 1.1.2.0
+
+* add an `objectE` function accepting extra fields during the parsing of an object
+
 ## 1.1.1.2
 
 * Drop support for old GHCs

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -50,6 +50,9 @@ tests = testGroup "Data.Yaml.Combinators"
   , testCase "Expect an object, get an object with an extra field" $
       runParser (object $ field "foo" number) (Object [("foo", Number 1), ("bar", String "x")]) @?=
         Left (ParseError 1 $ UnexpectedAsPartOf (Object [("bar", String "x")]) (Object [("foo", Number 1), ("bar", String "x")]))
+  , testCase "Expect an object, get an object with an extra field, with extra fields allowed" $
+      runParser (objectE $ field "foo" number) (Object [("foo", Number 1), ("bar", String "x")]) @?=
+        Right 1
   , testCase "Expect an object, get a field that doesn't match" $
       runParser (object $ field "foo" number) (Object [("foo", String "hi")]) @?=
         Left (ParseError 1 $ ExpectedInsteadOf ["Number"] (String "hi"))

--- a/yaml-combinators.cabal
+++ b/yaml-combinators.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                yaml-combinators
-version:             1.1.1.2
+version:             1.1.2.0
 synopsis:            YAML parsing combinators for improved validation and error reporting
 description:         Based on the article
                      <https://ro-che.info/articles/2015-07-26-better-yaml-parsing Better Yaml Parsing>.


### PR DESCRIPTION
This PR provides a fix for #7 